### PR TITLE
fix: Correct parameter definition in speakText utility

### DIFF
--- a/src/utils/speech.js
+++ b/src/utils/speech.js
@@ -2,8 +2,9 @@
  * Speaks the given text using the browser's Web Speech API.
  * @param {string} text The text to be spoken.
  * @param {string} lang The language code (e.g., 'en-US'). Defaults to 'en-US'.
+ * @param {string | null} preferredVoiceName Optional name of the voice to use.
  */
-export const speakText = (text, lang = 'en-US') => {
+export const speakText = (text, lang = 'en-US', preferredVoiceName = null) => {
   if (!('speechSynthesis' in window)) {
     console.warn('Browser does not support speech synthesis.');
     return;


### PR DESCRIPTION
Corrects an ESLint 'no-undef' error in src/utils/speech.js by adding 'preferredVoiceName' as an optional parameter to the speakText function. This was missed during recent enhancements to voice selection logic.

This commit is made on top of the Lead Portal - Phase 1 features:

- Lead Dashboard Revamp (Self-service & Team Overview widgets)
- Team Approvals Page (Leave & Regularization request management)
- Data Simulation for team members and pending requests
- Routing & Styling for new Lead Portal sections