### PR TITLE
fix: Remove duplicate useNavigate import in LeadDashboard

### DIFF
--- a/src/pages/dashboards/LeadDashboard.js
+++ b/src/pages/dashboards/LeadDashboard.js
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useNavigate, Link } from 'react-router-dom'; // Added Link
+import { useNavigate, Link } from 'react-router-dom';
 import { speakText, getTimeBasedGreeting, speakLogoutMessage } from '../../utils/speech';
 import ThemeSwitcher from '../../components/ThemeSwitcher';
 import '../Dashboard.css'; // Common dashboard styles


### PR DESCRIPTION
Corrects a SyntaxError caused by importing useNavigate twice.

This commit is made on top of the Lead Portal - Phase 2 features:
- Lead's own work status report submission logic updated.
- Team Task Management page (CRUD operations for team tasks).
- Updated TeamTasksOverviewWidget on Lead Dashboard.
- Routing and styling for new Lead Portal sections.