### PR TITLE
fix: Correct Dashboard.css import path in LeadDashboard

### DIFF
--- a/src/pages/dashboards/LeadDashboard.js
+++ b/src/pages/dashboards/LeadDashboard.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { speakText, getTimeBasedGreeting, speakLogoutMessage } from '../../utils/speech';
 import ThemeSwitcher from '../../components/ThemeSwitcher';
-import '../Dashboard.css'; // Common dashboard styles
+import './Dashboard.css'; // Corrected path
 import './lead/LeadDashboard.css'; // Specific styles for Lead Dashboard
 
 // Import Employee Dashboard Cards for self-service section


### PR DESCRIPTION
Corrects a 'Module not found' error by changing the import path for Dashboard.css from '../Dashboard.css' to './Dashboard.css' within LeadDashboard.js.

This commit is made on top of:
- fix: Remove duplicate useNavigate import in LeadDashboard
- Lead Portal - Phase 2 features (Reporting & Team Tasks)