### PR TITLE
FIX: Add missing Link import in ManagerDashboard

### DIFF
--- a/src/pages/dashboards/ManagerDashboard.js
+++ b/src/pages/dashboards/ManagerDashboard.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom'; // Added Link here
 import { speakText, getTimeBasedGreeting, speakLogoutMessage } from '../../utils/speech';
 import ThemeSwitcher from '../../components/ThemeSwitcher';
 import TeamQuickSummaryWidget from '../../components/managerDashboard/TeamQuickSummaryWidget'; // Import widget


### PR DESCRIPTION
Resolved ESLint error 'Link is not defined' by adding Link to the react-router-dom imports in src/pages/dashboards/ManagerDashboard.js. This makes the navigation links functional.